### PR TITLE
Python3.6 fix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,4 @@ pytest-cov = "*"
 bandit = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ markupsafe==1.1.1
 python-dateutil==2.8.0 ; python_version >= '2.7'
 s3transfer>=0.2
 six==1.12.0
-werkzeug==0.15.5
+werkzeug>=0.15.5

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ from setuptools import setup
 
 # Requirements
 install_reqs = parse_requirements('requirements.txt', session='dummy')
-reqs = [str(ir.req) for ir in install_reqs]
+try:
+    reqs = [str(ir.req) for ir in install_reqs]
+except:
+    reqs = [str(ir.requirement) for ir in install_reqs]
 
 setup(
     name='Flask-Boto3',


### PR DESCRIPTION
This patch addresses some issues related not working with Python 3.6.   My test was:
```
docker run --rm -ti -v $PWD:$PWD -w $PWD python:3.6.5 /bin/bash
python3 setup.py develop
pip install pipenv pytest pytest-cov mock
make test
```
